### PR TITLE
terminus site deploy no longer has --from

### DIFF
--- a/deploy_to_live.sh
+++ b/deploy_to_live.sh
@@ -4,7 +4,7 @@
 sitename=${PWD##*/}
 printf 'sitename: %s\n' "$sitename"
 
-cmd="terminus site deploy --site=$sitename --from=test --env=live --cc --note=Terminus"
+cmd="terminus site deploy --site=$sitename --env=live --cc --note=Terminus"
 echo "$cmd"
 eval "$cmd"
 

--- a/deploy_to_test.sh
+++ b/deploy_to_test.sh
@@ -4,7 +4,7 @@
 sitename=${PWD##*/}
 printf 'sitename: %s\n' "$sitename"
 
-cmd="terminus site deploy --site=$sitename --from=dev --env=test --cc --note=Terminus"
+cmd="terminus site deploy --site=$sitename --env=test --cc --note=Terminus"
 echo "$cmd"
 eval "$cmd"
 


### PR DESCRIPTION
At least for Terminus 0.10.4 and up.

``` bash
$ terminus cli version
+------------------+----------+
| Key              | Value    |
+------------------+----------+
| Terminus version | 0.10.4   |
| Terminus script  | terminus |
+------------------+----------+
```
