### PR TITLE
Handy script for installing devel_themer

### DIFF
--- a/install-devel-themer.sh
+++ b/install-devel-themer.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Currently, Theme Developer does not work with the latest version of
+# simplehtmldom API. You must use simplehtml API version 7.x-1.12 if you want
+# Theme Developer to function properly.
+# https://www.drupal.org/project/devel_themer
+
+drush dl -y devel_themer
+drush dl -y simplehtmldom-7.x-1.12
+drush en -y devel_themer


### PR DESCRIPTION
[devel_themer](https://www.drupal.org/project/devel_themer) is a handy dev tool for checking what theme template files apply to parts of a page.

It's a bit fiddly to install because it needs a given version of simplehtmldom, so let's script it.
