### PR TITLE
Add environment param, defaults to "live"

### DIFF
--- a/backup_create.sh
+++ b/backup_create.sh
@@ -4,12 +4,16 @@
 sitename=${PWD##*/}
 printf 'sitename: %s\n' "$sitename"
 
-cmd="terminus site backups create --site=$sitename --element=db --env=live"
+# Environment parameter will default to "live" if left out.
+if [ $# -eq 0 ]
+  then
+    echo "Live environment load"
+    env='live'
+  else
+    echo "$@ environment load"
+    env=$@
+fi
+
+cmd="terminus site backups create --site=$sitename --element=db --env=$env"
 echo "$cmd"
 eval "$cmd"
-# cmd="terminus site backups create --site=$sitename --element=db --env=test"
-# echo "$cmd"
-# eval "$cmd"
-# cmd="terminus site backups create --site=$sitename --element=db --env=dev"
-# echo "$cmd"
-# eval "$cmd"

--- a/backup_create.sh
+++ b/backup_create.sh
@@ -10,8 +10,8 @@ if [ $# -eq 0 ]
     echo "Live environment load"
     env='live'
   else
-    echo "$@ environment load"
-    env=$@
+    echo "$* environment load"
+    env=$*
 fi
 
 cmd="terminus site backups create --site=$sitename --element=db --env=$env"


### PR DESCRIPTION
`backup_create` => load live
`backup_create live` => load live
`backup_create test` => load test
`backup_create dev` => load dev
Probably works with multidev too.
