### PR TITLE
More handy stuff for newdb

### DIFF
--- a/drupal_script_aliases
+++ b/drupal_script_aliases
@@ -17,32 +17,32 @@ alias deploy-to-live=$DIR/deploy-to-live.sh
 # Environment parameter will default to "live" if left out.
 function newdb () {
 
-        if [ $# -eq 0 ]
-                then
-                        echo "Live environment load"
-                        local env='live'
-                else
-                        echo "$@ environment load"
-                        local env=$@
-        fi
-        drush sql-drop
-        local project=${PWD##*/}
-        echo "Folder name :" $project
-        terminus site backups create --site=$project --element=db --env=$env
-        terminus site backups get --site=$project --element=db --env=$env --latest --to=/tmp
-        local dbname=$project"_"
-        local db="$(ls -t /tmp/$dbname* | head -1)"
-        echo "Database filename :" $db
-        zcat < $db | drush sql-cli
-        drush updb --yes
-        echo
-        echo "Database is ready!"
-        echo
-        drush uli
-        echo "************************* ^^^ Login URL ^^^ *************************"
-        echo
-        drush en views_ui --yes
-        install-stage-file-proxy.sh
+  if [ $# -eq 0 ]
+    then
+      echo "Live environment load"
+      local env='live'
+    else
+    echo "$@ environment load"
+    local env=$@
+  fi
+  drush sql-drop
+  local project=${PWD##*/}
+  echo "Folder name :" $project
+  terminus site backups create --site=$project --element=db --env=$env
+  terminus site backups get --site=$project --element=db --env=$env --latest --to=/tmp
+  local dbname=$project"_"
+  local db="$(ls -t /tmp/$dbname* | head -1)"
+  echo "Database filename :" $db
+  zcat < $db | drush sql-cli
+  drush updb --yes
+  echo
+  echo "Database is ready!"
+  echo
+  drush uli
+  echo "************************* ^^^ Login URL ^^^ *************************"
+  echo
+  drush en views_ui --yes
+  install-stage-file-proxy.sh
 }
 
 # Function aliases.

--- a/drupal_script_aliases
+++ b/drupal_script_aliases
@@ -22,8 +22,8 @@ function newdb () {
       echo "Live environment load"
       local env='live'
     else
-    echo "$@ environment load"
-    local env=$@
+    echo "$* environment load"
+    local env=$*
   fi
   drush sql-drop
   local project=${PWD##*/}

--- a/drupal_script_aliases
+++ b/drupal_script_aliases
@@ -34,7 +34,13 @@ function newdb () {
         local db="$(ls -t /tmp/$dbname* | head -1)"
         echo "Database filename :" $db
         zcat < $db | drush sql-cli
-        drush updb
+        drush updb --yes
+        echo
+        echo "Database is ready!"
+        echo
+        drush uli
+        drush en views_ui --yes
+        install-stage-file-proxy
 }
 
 # Function aliases.

--- a/drupal_script_aliases
+++ b/drupal_script_aliases
@@ -39,8 +39,10 @@ function newdb () {
         echo "Database is ready!"
         echo
         drush uli
+        echo "************************* ^^^ Login URL ^^^ *************************"
+        echo
         drush en views_ui --yes
-        install-stage-file-proxy
+        install-stage-file-proxy.sh
 }
 
 # Function aliases.


### PR DESCRIPTION
- Skip prompt to apply db updates: `drush updb --yes`
- Make it clear when db is usable: `echo "Database is ready!"`
- Create user login: `drush uli` and make the link clear
- Enable Views UI for local, it's often turned off on live: `drush en views_ui --yes`
- `install-stage-file-proxy` very useful for local
- Fix ShellCheck (SC2145 & SC2124, same as https://github.com/nordsoftware/drupal-scripts/commit/273df2f811a7dc25694253fef4c07b4a8f440b1d)
- Two-space indents are standard
